### PR TITLE
Feat/function address mapping

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -19,7 +19,7 @@ let globalInputPath = null;
 let functionAddressMapPath = null;
 let isLldbConnected = false; // Track if LLDB is connected to the gdb server
 let isAnchor = false; // Track if the project is an Anchor project
-let selectedAnchorProgramName = null;; // If it's an Anchor project with multiple programs, this will hold the selected program name(if its null then its single program project) 
+let selectedAnchorProgramName = null; // If it's an Anchor project with multiple programs, this will hold the selected program name(if its null then its single program project) 
 
 function getCommandPath(command) {
   const homeDir = os.homedir();

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
       },
       {
         "command": "extension.reRunProcessLaunch",
-        "title": "Re-run process launch"
+        "title": "Continue process"
       },
       {
         "command": "extension.runAgaveLedgerToolForBreakpoint",

--- a/package.json
+++ b/package.json
@@ -37,6 +37,10 @@
       {
         "command": "extension.reRunProcessLaunch",
         "title": "Re-run process launch"
+      },
+      {
+        "command": "extension.runAgaveLedgerToolForBreakpoint",
+        "title": "Run Agave Ledger Tool for Breakpoint"
       }
     ],
     "keybindings": [


### PR DESCRIPTION
# What

1. I have implemented breakpoints to be set on `address` instead of line.
2. When user have set his `breakpoints` he use command to start agave-ledger-tool on a specific breakpoint.
3. It runs the agave-ledger-tool using the `input.json` user have created for the specific function.
4. Starts stepping using `next`


# Plan
- Implement breakpoint setting based on instruction address rather than source line(bp.location), since only one instruction can be debugged per run.

- Ensure that when hitting a breakpoint in a different instruction, the user restarts agave-ledger-tool to load the new instruction input.

- Enable solana-lldb to reuse the same .debug symbols and reconnect automatically on each new breakpoint.

# What has been done
1. Breakpoints are now set on instruction addresses instead of source lines.
2. After user sets breakpoints, they start agave-ledger-tool targeting a specific breakpoint.
3. The tool runs with user-provided input JSON matching the instruction.

Step-through debugging is started when user uses `Continue process` or type `continue` in solanaLLDB

Usage Rules
- User must create an input folder with a .json file per instruction named exactly after the instruction, e.g. input/initialize.json for pub fn initialize.

- User must have Solana toolchain and LLVM tools (llvm-objdump, solana-lldb) in their system PATH.

- Breakpoints can only be set inside lib.rs.

For native Solana programs, instructions to debug must have #[no_mangle] and #[inline(never)] annotations to ensure proper symbol visibility and debugging.

