### PR TITLE
Continue process command fix

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -401,7 +401,7 @@ function reRunProcessLaunch() {
   
   if (terminal) {
     activeTerminal = terminal;
-    terminal.sendText("continue"); // Resume the process in the LLDB debugger (process launch -- --nocapture)
+    terminal.sendText("next"); // Resume the process in the LLDB debugger (process launch -- --nocapture)
   } else {
     vscode.window.showErrorMessage("Solana LLDB Debugger terminal not found.");
     startSolanaDebugger();


### PR DESCRIPTION
# What

- Small fix changed from `continue` to `next` because continue should be used only once in the beggining when resuming on a breakpoint and can crash later.

- Next is better approach it doesn't crash in any case 