### PR TITLE
fix: auto-stop debugger when test execution ends or fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ All notable changes to the "Gimlet" extension will be documented in this file.
 - Recalculate config paths on hot-reload so cached values stay in sync
 - Load existing gimlet.json values into globalState on activation so sbfTraceDir is picked up immediately
 - Reset sbfTraceDir to default when removed from gimlet.json instead of keeping the stale value
+- Auto-stop debugger when test execution ends or fails instead of polling forever
 
 ## [0.1.12] - 2026-04-06
 

--- a/src/extension.js
+++ b/src/extension.js
@@ -153,6 +153,11 @@ async function activateDebugger(context) {
         // Listener to handle when debug ends
         const debugListener = vscode.debug.onDidTerminateDebugSession(session => {
             log('Debug session terminated:', session.name);
+            if (portManager.isPolling()) {
+                portManager.scheduleCleanup(() => cleanupDebuggerSession());
+            } else {
+                cleanupDebuggerSession();
+            }
         });
 
         const stopDisposable = vscode.commands.registerCommand('gimlet.stopSession', () => {

--- a/src/managers/portManager.js
+++ b/src/managers/portManager.js
@@ -9,6 +9,7 @@ const { log } = require('../logger');
 class PortManager {
     constructor() {
         this.pollingToken = null;
+        this.cleanupTimer = null;
     }
 
     async isPortOpen(port) {
@@ -45,6 +46,7 @@ class PortManager {
                     });
                 });
 
+                this.cancelCleanupTimer();
                 log('Starting debug session on port:', port);
                 const lldbConfig = vscode.workspace.getConfiguration('lldb');
                 const originalLibrary = lldbConfig.get('library');
@@ -88,7 +90,28 @@ class PortManager {
         this.pollingToken = null;
     }
 
+    isPolling() {
+        return this.pollingToken !== null;
+    }
+
+    scheduleCleanup(onCleanup) {
+        this.cancelCleanupTimer();
+        this.cleanupTimer = setTimeout(() => {
+            log('No new program detected after session ended, cleaning up.');
+            this.cleanup();
+            if (onCleanup) onCleanup();
+        }, 3000);
+    }
+
+    cancelCleanupTimer() {
+        if (this.cleanupTimer) {
+            clearTimeout(this.cleanupTimer);
+            this.cleanupTimer = null;
+        }
+    }
+
     cleanup() {
+        this.cancelCleanupTimer();
         this.pollingToken = null;
     }
 }


### PR DESCRIPTION
**Detailed description**:
* add grace period timer to detect when no more programs are coming after a debug session terminates. The polling loop & session are cleaned up automatically, including handling test completion/failure

**Which issue(s) this PR fixes**:
Fixes #None

**Checklist**
- [ ] Documentation added