### PR TITLE
fix: set PYTHONPATH for LLDB Python on all platforms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ All notable changes to the "Gimlet" extension will be documented in this file.
 - Load existing gimlet.json values into globalState on activation so sbfTraceDir is picked up immediately
 - Reset sbfTraceDir to default when removed from gimlet.json instead of keeping the stale value
 - Auto-stop debugger when test execution ends or fails instead of polling forever
+- Auto-set PYTHONPATH for LLDB Python module resolution on all platforms 
 
 ## [0.1.12] - 2026-04-06
 

--- a/src/managers/debugConfigManager.js
+++ b/src/managers/debugConfigManager.js
@@ -23,10 +23,27 @@ class DebugConfigManager {
         );
     }
 
+    getLldbPythonPath() {
+        const libDir = path.join(
+            os.homedir(),
+            '.cache',
+            'solana',
+            `v${globalState.platformToolsVersion}`,
+            'platform-tools',
+            'llvm',
+            'lib'
+        );
+
+        const pythonDir = fs.readdirSync(libDir).find(entry => entry.startsWith('python'));
+        if (!pythonDir) return null;
+
+        return path.join(libDir, pythonDir, 'dist-packages');
+    }
+
     getLaunchConfig(currentTcpPort, metadataId) {
         const metadataFile = metadataFilePath(metadataId);
         const scriptsDir = this.getSolanaScriptsDir();
-        return {
+        const config = {
             type: 'lldb',
             request: 'launch',
             name: `Sbpf Debug ${metadataId.slice(0, 8)}`,
@@ -42,6 +59,15 @@ class DebugConfigManager {
                 `solana_save_output ${metadataFile} process plugin packet monitor metadata`,
             ],
         };
+
+        const pythonPath = this.getLldbPythonPath();
+        if (pythonPath) {
+            config.env = {
+                PYTHONPATH: pythonPath + ':${env:PYTHONPATH}',
+            };
+        }
+
+        return config;
     }
 
     async readMetadata(metadataId, timeoutMs = 10000, intervalMs = 100) {


### PR DESCRIPTION
Auto-detect the Python version directory under platform-tools and set PYTHONPATH in the debug launch config. Fixes LLDB failing to find the lldb.embedded_interpreter module on Ubuntu 22.04/24.04.