### PR TITLE
fix: set PYTHONPATH for LLDB Python on all platforms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to the "Gimlet" extension will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+
+- Set PYTHONPATH for LLDB Python module resolution on all platforms via initCommands   
+
 ## [0.1.13] - 2026-04-16
 
 ### Added

--- a/src/managers/debugConfigManager.js
+++ b/src/managers/debugConfigManager.js
@@ -37,37 +37,41 @@ class DebugConfigManager {
         const pythonDir = fs.readdirSync(libDir).find(entry => entry.startsWith('python'));
         if (!pythonDir) return null;
 
-        return path.join(libDir, pythonDir, 'dist-packages');
+        const pythonLibDir = path.join(libDir, pythonDir);
+        const packagesDir = fs.readdirSync(pythonLibDir).find(entry => entry.endsWith('-packages'));
+        if (!packagesDir) return null;
+
+        return path.join(pythonLibDir, packagesDir);
     }
 
     getLaunchConfig(currentTcpPort, metadataId) {
         const metadataFile = metadataFilePath(metadataId);
         const scriptsDir = this.getSolanaScriptsDir();
-        const config = {
+        const initCommands = [];
+
+        const pythonPath = this.getLldbPythonPath();
+        if (pythonPath) {
+            initCommands.push(`script import sys; sys.path.insert(0, "${pythonPath}")`);
+        }
+
+        initCommands.push(
+            `command script import "${path.join(scriptsDir, 'lldb_lookup.py')}"`,
+            `command script import "${path.join(scriptsDir, 'solana_lookup.py')}"`,
+            `command script import "${path.join(scriptsDir, 'solana_input_deserialize_abiv1.py')}"`,
+            `command script import "${path.join(scriptsDir, 'solana_save_output.py')}"`,
+        );
+
+        return {
             type: 'lldb',
             request: 'launch',
             name: `Sbpf Debug ${metadataId.slice(0, 8)}`,
-            initCommands: [
-                `command script import "${path.join(scriptsDir, 'lldb_lookup.py')}"`,
-                `command script import "${path.join(scriptsDir, 'solana_lookup.py')}"`,
-                `command script import "${path.join(scriptsDir, 'solana_input_deserialize_abiv1.py')}"`,
-                `command script import "${path.join(scriptsDir, 'solana_save_output.py')}"`,
-            ],
+            initCommands,
             targetCreateCommands: [],
             processCreateCommands: [`gdb-remote 127.0.0.1:${currentTcpPort}`],
             postRunCommands: [
                 `solana_save_output ${metadataFile} process plugin packet monitor metadata`,
             ],
         };
-
-        const pythonPath = this.getLldbPythonPath();
-        if (pythonPath) {
-            config.env = {
-                PYTHONPATH: pythonPath + ':${env:PYTHONPATH}',
-            };
-        }
-
-        return config;
     }
 
     async readMetadata(metadataId, timeoutMs = 10000, intervalMs = 100) {


### PR DESCRIPTION
**Detailed description**:
* inject sys.path into LLDB's embedded Python via initCommands instead of the launch config env                                                                                                                                                                          

**Which issue(s) this PR fixes**:
Fixes #None