### PR TITLE
fix: fail immediately when no debug session is found on the port

### DIFF
--- a/src/managers/portManager.js
+++ b/src/managers/portManager.js
@@ -29,7 +29,7 @@ class PortManager {
 
         const isOpen = await this.isPortOpen(port);
         if (!isOpen) {
-            vscode.window.showErrorMessage(`Gimlet: No debug session found on port ${port}. Make sure your test is running with SBF_DEBUG_PORT=${port}.`);
+            vscode.window.showErrorMessage(`Gimlet: No debug session found on port ${port}. Make sure your test is running with SBF_DEBUG_PORT=${port}, or change the port in .vscode/gimlet.json (tcpPort).`);
             return;
         }
 

--- a/src/managers/portManager.js
+++ b/src/managers/portManager.js
@@ -27,6 +27,12 @@ class PortManager {
     async listenAndStartDebugForPort(port) {
         if (this.pollingToken) return;
 
+        const isOpen = await this.isPortOpen(port);
+        if (!isOpen) {
+            vscode.window.showErrorMessage(`Gimlet: No debug session found on port ${port}. Make sure your test is running with SBF_DEBUG_PORT=${port}.`);
+            return;
+        }
+
         const myToken = Symbol();
         this.pollingToken = myToken;
 


### PR DESCRIPTION
**Detailed description**:
* fix: fail immediately when no debug session is found on the port

**Which issue(s) this PR fixes**:
Fixes #None