### PR TITLE
chore: resolve TODO on .so file size in scanDeployDirectory

### DIFF
--- a/src/extension.js
+++ b/src/extension.js
@@ -61,7 +61,10 @@ async function scanDeployDirectory(session) {
         soCount++;
 
         const soPath = path.join(artifactsPath, file);
-        const hash = crypto.createHash('sha256').update(fs.readFileSync(soPath)).digest('hex'); // TODO(lime): any chance of too big .so files?
+        // Sync read+hash is fine here: deployed programs are bounded by the
+        // 10 MiB account data cap (MAX_PERMITTED_DATA_LENGTH), so worst case
+        // stays in the single-digit ms range.
+        const hash = crypto.createHash('sha256').update(fs.readFileSync(soPath)).digest('hex');
         session.setProgramNameForHash(hash, file);
 
         session.executablesPaths[file] = {


### PR DESCRIPTION
Hey,

I was exploring the gimlet VScode plugin and wanted to help on a simple TO-DO I saw in the source code, it's not much but it could maybe help : 

**Issue :** 
Resolves the `TODO(lime): any chance of too big .so files?` in `scanDeployDirectory`.

**Answer:**

-Deployed Solana programs are bounded by [`MAX_PERMITTED_DATA_LENGTH`](https://docs.rs/solana-system-interface/latest/solana_system_interface/constant.MAX_PERMITTED_DATA_LENGTH.html) = 10 MB (program account data cap), so a local `.so` has no reason to exceed it.
-Measured `readFileSync` + SHA-256 at the theoretical worst case (10 MB): ~8 ms on my macbook pro M2.


So I don't think there is any chance of too big .so files. Even Jupiter V6 program is like 2.9 MB (.so).


Best,

Léo






