### PR TITLE
perf(port): replace systeminformation with native TCP bind probe

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,9 +8,6 @@
             "name": "gimlet",
             "version": "0.2.2",
             "license": "MIT",
-            "dependencies": {
-                "systeminformation": "^5.31.6"
-            },
             "devDependencies": {
                 "eslint": "^10.2.0",
                 "globals": "^17.4.0",
@@ -851,32 +848,6 @@
             "license": "MIT",
             "engines": {
                 "node": ">=8"
-            }
-        },
-        "node_modules/systeminformation": {
-            "version": "5.31.8",
-            "resolved": "https://registry.npmjs.org/systeminformation/-/systeminformation-5.31.8.tgz",
-            "integrity": "sha512-/HGurKdgjYGbfwCPSokoX4WAlasVxuj1SnTukLiIYHPkjbDbN1PMATj8mkHpqkVzUF34y5ZyCY1TMKP32AI9rA==",
-            "license": "MIT",
-            "os": [
-                "darwin",
-                "linux",
-                "win32",
-                "freebsd",
-                "openbsd",
-                "netbsd",
-                "sunos",
-                "android"
-            ],
-            "bin": {
-                "systeminformation": "lib/cli.js"
-            },
-            "engines": {
-                "node": ">=8.0.0"
-            },
-            "funding": {
-                "type": "Buy me a coffee",
-                "url": "https://www.buymeacoffee.com/systeminfo"
             }
         },
         "node_modules/type-check": {

--- a/package.json
+++ b/package.json
@@ -97,7 +97,5 @@
         "type": "git",
         "url": "https://github.com/LimeChain/gimlet.git"
     },
-    "dependencies": {
-        "systeminformation": "^5.31.6"
-    }
+    "dependencies": {}
 }

--- a/src/managers/portManager.js
+++ b/src/managers/portManager.js
@@ -1,5 +1,5 @@
 const crypto = require('crypto');
-const si = require('systeminformation');
+const net = require('net');
 const vscode = require('vscode');
 const { debugConfigManager } = require('./debugConfigManager');
 const { getDebuggerSession } = require('./sessionManager');
@@ -65,13 +65,12 @@ class PortManager {
     }
 
     async isPortOpen(port) {
-        try {
-            const connections = await si.networkConnections();
-            return connections.some(c => c.localPort === String(port) && (c.protocol === 'tcp4' || c.protocol === 'tcp') && c.state === 'LISTEN');
-        } catch (err) {
-            log(`Port check failed: ${err.message}`);
-            return false;
-        }
+        return new Promise((resolve) => {
+            const server = net.createServer();
+            server.once('error', (err) => resolve(err.code === 'EADDRINUSE'));
+            server.once('listening', () => server.close(() => resolve(false)));
+            server.listen(port, '127.0.0.1');
+        });
     }
 
     async listenAndStartDebugForPort(port) {


### PR DESCRIPTION
## Summary

`isPortOpen` called `si.networkConnections()`, which shells out to `lsof`/`netstat` and scans every connection on the machine just to check one port's state. Replaced with a native bind probe (`net.createServer().listen()`) — same "check state, don't connect" safety property, roughly 1/700th–1/4000th the cost, and drops the `systeminformation` dependency, which existed for this one call.

This isn't just a during-a-session optimization — `StateMonitor` polls it every 1-2s the whole time the Gimlet pane is visible, not only while actively debugging.

## Why not `net.connect()`?

A connect-based probe was actually the original implementation here, and it was deliberately removed (`7fea373`) — but for a narrower reason than "avoid `net`": it was being used to monitor whether an *already-connected* debugger session was still alive, which a fresh connect can't do. `anza-xyz/sbpf`'s gdbstub accepts exactly one client and drops its listener right after, so any later connect attempt gets refused whether the real session is healthy or dead. `netstat`'s `ESTABLISHED`-state check fixed that correctly.

When `si.networkConnections()` later replaced the plain `netstat` call (`2488386`), it was for an unrelated reason (cross-platform parsing), not because of the connect-probe bug above — but it kept the same "don't use `net` for port checks" habit anyway. That habit doesn't actually apply to the check this PR touches: `isPortOpen` only checks `LISTEN` state *before* a session starts, and a bind probe is safe for it the same way `netstat`/`si` are — it never calls `.accept()` on the target, just without the subprocess. Verified against a fixture mimicking the single-accept gdbstub: 0/10 probes reached its accept handler.

## Benchmarks

30 iterations per case, against the actual `isPortOpen` in this PR vs. `si.networkConnections()` reconstructed from the removed implementation:

| Scenario | This PR (`net` bind-probe) | Before (`si.networkConnections`) |
|---|---|---|
| Port closed | 0.19ms mean (p95: 1.32ms) | 86.58ms mean (p95: 95.02ms) |
| Port open | 0.02ms mean (p95: 0.05ms) | 89.21ms mean (p95: 99.51ms) |
| 30 sequential ticks (`StateMonitor`-realistic) | 0.6ms total | 2562.7ms total — ~4267x |
